### PR TITLE
Add support to specifying job user

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ For verification `molecule/resources/verify.yml` run after the role has been app
         - name: requested job by the weekday
           weekday: "1"
           job: "ls -alh > /dev/null"
+        - name: requested job by specific user
+          hour: "23"
+          job: "ls -alh > /dev/null"
+          user: "appuser"
 ```
 
 Also see a [full explanation and example](https://robertdebock.nl/how-to-use-these-roles.html) on how to use these roles.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,6 +26,7 @@
     weekday: "{{ item.weekday | default(omit) }}"
     job: "{{ item.job }}"
     state: "{{ item.state | default('present') }}"
+    user: "{{ item.user | default(omit) }}"
   loop: "{{ cron_jobs }}"
   notify:
     - restart cron


### PR DESCRIPTION
---
name: Add support to create jobs for specific users
about: This is supported by Ansible's built-in module and not used by this role.

---

Added an additional property to the job definition that will assign the task to the specified user or omit in case none is specified. Omitting the value would cause it to use the current behavior.

A different approach I tried to work around this limitation was to set "become_user" to the desired user the job should be assigned to but that lead into privilege issues when the handler tries to restart crontab.

With the proposed change, it worked just fine.
