### PR TITLE
Add support for Arch

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,9 @@ galaxy_info:
     - name: Amazon
       versions:
         - 2018.03
+    - name: Archlinux
+      versions:
+        - all
     - name: EL
       versions:
         - 7

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -16,5 +16,6 @@ _cron_service:
   Alpine: '[]'
   Debian: cron
   Suse: cron
+  Archlinux: cronie
 
 cron_service: "{{ _cron_service[ansible_os_family] | default(_cron_service['default']) }}"


### PR DESCRIPTION
**Describe the change**

Add support for Arch.

On arch, the both the package _and service_ are `cronie`.

**Testing**

Adding required key under the value for `ansible_os_family` on my arch box.