### PR TITLE
Add special_time parameter to cron task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,6 +58,7 @@
     day: "{{ item.day | default(omit) }}"
     month: "{{ item.month | default(omit) }}"
     weekday: "{{ item.weekday | default(omit) }}"
+    special_time: "{{ item.special_time | default(omit) }}"
     job: "{{ item.job }}"
     state: "{{ item.state | default('present') }}"
     user: "{{ item.user | default(omit) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: import assert.yml
   ansible.builtin.import_tasks: assert.yml
-  run_once: yes
+  run_once: true
   delegate_to: localhost
 
 - name: install cron
@@ -16,7 +16,7 @@
     path: "{{ cron_configuration }}"
     line: "SHELL={{ cron_shell }}"
     regexp: "^SHELL"
-    create: yes
+    create: true
     mode: "0600"
   notify:
     - restart cron
@@ -26,7 +26,7 @@
     path: "{{ cron_configuration }}"
     line: "PATH={{ cron_path }}"
     regexp: "^PATH"
-    create: yes
+    create: true
     mode: "0600"
   notify:
     - restart cron
@@ -36,7 +36,7 @@
     path: "{{ cron_configuration }}"
     line: "MAILTO={{ cron_mailto }}"
     regexp: "^MAILTO"
-    create: yes
+    create: true
     mode: "0600"
   notify:
     - restart cron
@@ -45,7 +45,7 @@
   ansible.builtin.service:
     name: "{{ cron_service }}"
     state: started
-    enabled: yes
+    enabled: true
   when:
     - cron_service is defined
     - cron_service | length


### PR DESCRIPTION
---
name: Pull request
about: Add the special_time parameter to the cron task

---

Special time specification nickname.

Choices:
    annually
    daily
    hourly
    monthly
    reboot
    weekly
    yearly


