### PR TITLE
fix ansible 12 broken conditional

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,4 +6,4 @@
     name: "{{ cron_service }}"
     state: restarted
   when:
-    - cron_service | length
+    - cron_service | length > 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,7 +49,7 @@
     enabled: true
   when:
     - cron_service is defined
-    - cron_service | length
+    - cron_service | length > 0
 
 - name: Schedule requested cron jobs
   ansible.builtin.cron:


### PR DESCRIPTION
---
name: Pull request
about: fix `fatal: [hostname]: FAILED! => {"changed": false, "msg": "Task failed: Conditional result (True) was derived from value of type 'int' at '/usr/share/ansible/roles/robertdebock.cron/tasks/main.yml:52:7'. Conditionals must have a boolean result."}`
---

**Describe the change**

https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_12.html#broken-conditionals

> This expression relies on an implicit truthy evaluation. An explicit predicate with a boolean result, such as | length > 0 or is truthy, should be used instead.


**Testing**

Locally tested with `molecule test`

The error can be temporarily reduced to a warning with the ALLOW_BROKEN_CONDITIONALS config setting, but the proper fix is to use explicit boolean comparisons
